### PR TITLE
added some missing pieces to the documentation

### DIFF
--- a/docs/sphinx/base-tasks.rst
+++ b/docs/sphinx/base-tasks.rst
@@ -202,7 +202,7 @@ Example::
         name: USER
         home: HOME
     - base.echo:
-        msg: "I am {name} and {{home}} is my castle."
+        msg: "I am {{name}} and {{home}} is my castle."
 
 .. warning::
    Only simple, non-nested context parameters can be used in ``base.getenv``!
@@ -214,7 +214,7 @@ Sets one or more environment variables from values of the ScriptEngine context.
 
 Usage::
 
-    - base.getenv:
+    - base.setenv:
         <ENV_VAR_NAME>: <CONTEXT_PARAMETER>
         [...]
 

--- a/docs/sphinx/concepts.rst
+++ b/docs/sphinx/concepts.rst
@@ -43,10 +43,16 @@ within other Python programs, without ever defining tasks in YAML scripts.
 Jobs
 ----
 
-Similarly to the `Tasks`, `Jobs` are also units of work for ScriptEngine, with
-the difference that `Jobs` use specifiers to manage the `task` (e.g. add
-conditionals) or `sequence of tasks` (see :ref:`Writing Scripts:Conditionals
-(\`when\` clauses)` and :ref:`Writing Scripts:Do`).
+Similar to tasks, `jobs` are units of work for ScriptEngine. Jobs can extend
+tasks in two ways:
+
+    * jobs can join a number of tasks into a sequence, and
+    * jobs can add contitionals and loops to tasks.
+
+Corresponding to these two cases, jobs use the special ``do`` keyword to specify
+sequences of tasks (see :ref:`scripts:Do`), and/or ``when`` or ``loop`` clauses
+clauses to specify :ref:`scripts:conditionals` and :ref:`scripts:loops`,
+respectively.
 
 
 Scripts

--- a/docs/sphinx/concepts.rst
+++ b/docs/sphinx/concepts.rst
@@ -13,7 +13,7 @@ Tasks
 -----
 
 A task is the basic unit of work for ScriptEngine. It is the building block for
-scripts (see next section) and also the individual item a ScriptEngine instance
+scripts (see `Scripts` section) and also the individual item a ScriptEngine instance
 (see even later) will handle.
 
 Tasks "do things". This can be simple things, like copying a file or writing
@@ -38,6 +38,15 @@ packages.
 Technically, a task is a Python class that is derived from the ``Task`` class
 that ScriptEngine provides. In fact, it is possible to use ScriptEngine from
 within other Python programs, without ever defining tasks in YAML scripts.
+
+
+Jobs
+----
+
+Similarly to the `Tasks`, `Jobs` are also units of work for ScriptEngine, with
+the difference that `Jobs` use specifiers to manage the `task` (e.g. add
+conditionals) or `sequence of tasks` (see :ref:`Writing Scripts:Conditionals
+(\`when\` clauses)` and :ref:`Writing Scripts:Do`).
 
 
 Scripts

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -32,6 +32,8 @@ extensions = [
     'sphinx.ext.autosectionlabel',
 ]
 
+autosectionlabel_prefix_document = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -48,6 +48,19 @@ This script will write "Hello, Earth!". There are two tasks: ``base.context``
 and ``base.echo``, which are the two elements of a YAML list.
 
 
+Do
+--
+
+The job specifier ``do`` allows for grouping a sequence of `tasks` inside one
+single `job`. For example::
+
+    - do:
+      - base.context:
+          planet: Earth
+      - base.echo:
+          msg: "Hello, {{planet}}!"
+
+
 Loops
 -----
 
@@ -186,8 +199,30 @@ context::
 Conditionals (`when` clauses)
 -----------------------------
 
-...
+It is possible to control that a given job runs exclusively under a certain
+condition, by using the ``when`` specifier. Here is an example::
 
+    - base.context:
+        year: 1963
+    - base.echo:
+        msg: 'Peter, Paul and Mary most famous song'
+      when: "{{year==1963}}"
+
+It is possible to combine ``when`` with ``do``, to execute a sequence of tasks
+under the same condition::
+    - base.context:
+        year: 1963
+    - when: "{{year==1963}}"
+      do:
+        - base.echo:
+            msg: 'Puff, the magic dragon'
+        - base.echo:
+            msg: 'lives by the sea'
+
+.. note::
+   The conditional ``when`` does not allow for an ``else`` syntax or similar.
+   If you need that, please add another job to the script with a ``when``
+   evaluating the complementary condition.
 
 Special YAML Features
 ---------------------

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -51,14 +51,17 @@ and ``base.echo``, which are the two elements of a YAML list.
 Do
 --
 
-The job specifier ``do`` allows for grouping a sequence of `tasks` inside one
-single `job`. For example::
+The job specifier ``do`` allows for grouping a `list of tasks` inside one single
+job (see :ref:`concepts:jobs`). For example::
 
     - do:
       - base.context:
           planet: Earth
       - base.echo:
           msg: "Hello, {{planet}}!"
+
+This is most often used in order to apply a ``when`` clause or a ``loop`` to a
+sequence of tasks.
 
 
 Loops
@@ -196,11 +199,11 @@ context::
         in: '{{people}}'
 
 
-Conditionals (`when` clauses)
------------------------------
+Conditionals
+------------
 
 It is possible to control that a given job runs exclusively under a certain
-condition, by using the ``when`` specifier. Here is an example::
+condition, by using a ``when`` clause. Here is an example::
 
     - base.context:
         year: 1963
@@ -208,8 +211,19 @@ condition, by using the ``when`` specifier. Here is an example::
         msg: 'Peter, Paul and Mary most famous song'
       when: "{{year==1963}}"
 
-It is possible to combine ``when`` with ``do``, to execute a sequence of tasks
-under the same condition::
+.. hint::
+    Because dict keys are not ordered in YAML, the second task in the previous
+    example is equivalent to::
+
+        - when: "{{year==1963}}"
+          base.echo:
+            msg: 'Peter, Paul and Mary most famous song'
+
+    Some might find it easier to read if the condition preceeds the task body.
+
+The ``when`` clause can be combined with the ``do`` keyword, to execute a
+sequence of tasks conditionally::
+
     - base.context:
         year: 1963
     - when: "{{year==1963}}"
@@ -220,9 +234,10 @@ under the same condition::
             msg: 'lives by the sea'
 
 .. note::
-   The conditional ``when`` does not allow for an ``else`` syntax or similar.
-   If you need that, please add another job to the script with a ``when``
-   evaluating the complementary condition.
+    There is no `else` clause in ScriptEngine. If the equivalent to an
+    if-then-else logic is needed, two ``when`` clauses with complementary
+    expressions must be used.
+
 
 Special YAML Features
 ---------------------


### PR DESCRIPTION
- Some suggestions for completing the documentation and fixing typos.
- The example in the `base-tasks.rst` for `chdir` does not work "out-of-the-box":
  ```yaml
      base.chdir:
          path: "{{se.cli.pwd}}"
  ```
  I cannot come up with a good suggestion for a better example, or I might be doing something wrong, and that's why is not working for me?