### PR TITLE
New base task: base.context.from

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+ScriptEngine 0.Y.Z
+===================
+
+Features
+--------
+- #77: Add base.context.from (thanks @mandresm for suggesting)
+
+
 ScriptEngine 0.13.1
 ===================
 

--- a/docs/sphinx/base-tasks.rst
+++ b/docs/sphinx/base-tasks.rst
@@ -141,11 +141,11 @@ particular, ``base.context.from`` accepts one of two arguments, ``dict`` or
         file: <FILE_NAME>  # optional, mutual exclusive
 
 
-If given the ``dict`` argument, the context update is specified by the
-dictionary given as argument value. This may sound rather similar to the
-standard ``base.context``, but it allows greater flexibility, because the
-argument value can be taken from the context itself. This could be used, for
-example, to allow script users to overwrite default values::
+If given the ``dict`` argument, the context update is specified by the argument
+value, which must be a dictionary. This may sound rather similar to the standard
+``base.context``, but it allows greater flexibility because the argument value
+can be taken from the context itself. For example, one could implement
+overwriteable default settings using this feature::
 
     # Let the user set preferred values
     - base.context:
@@ -388,7 +388,7 @@ and::
         False:   No time logging after each task. Does not affect statistic
                  collection.
         'info':  Logging to the info logger.
-        'debug': Logging to the debug logger§
+        'debug': Logging to the debug logger
 
 
 Template task

--- a/docs/sphinx/base-tasks.rst
+++ b/docs/sphinx/base-tasks.rst
@@ -127,6 +127,60 @@ current values in the ScriptEngine context. This can be used to clean data::
     # mylist is now [3, 4]
 
 
+Context.from task
+-----------------
+This is an extension of ``base.context``. It updates the ScriptEngine context in
+the same way, but it allows to "read" the context update from another source
+instead of explicitly specifying the name-value pairs as task arguments. In
+particular, ``base.context.from`` accepts one of two arguments, ``dict`` or
+``file``. The arguments are mutual exclusive::
+
+    base.context.from:
+        # exactly one of the two arguments:
+        dict: <DICTIONARY>  # optional, mutual exclusive
+        file: <FILE_NAME>  # optional, mutual exclusive
+
+
+If given the ``dict`` argument, the context update is specified by the
+dictionary given as argument value. This may sound rather similar to the
+standard ``base.context``, but it allows greater flexibility, because the
+argument value can be taken from the context itself. This could be used, for
+example, to allow script users to overwrite default values::
+
+    # Let the user set preferred values
+    - base.context:
+        user_config:
+            foo: 5
+    # [... later (could be in another script) ...]
+    # Set default values
+    - base.context:
+        foo: 1
+        bar: 2
+    # Overwrite defaults with user preferences
+    - base.context.from:
+        dict: "{{ user_config  }}"
+    # result: foo==5, bar==2
+
+The ``file`` argument of ``base.context.from`` can be used to read context
+values from a YAML file::
+
+    # data.yml
+    foo: 4
+    bar: 5
+
+    # script.yml
+    - base.context.from:
+        file: data.yml
+
+When running the scripte with ``se script.yml``, the context will contain
+``foo==4`` and ``bar==5``, provided that the file ``data.yml`` can be found in
+the current directory.
+
+The only supported file format for the time being is YAML. The content of the
+file must be a, possibly nested, dictionary (i.e. single values or lists are not
+allowed).
+
+
 Copy task
 ---------
 This task copies the file or directory given by ``src`` to ``dst``. If ``src``

--- a/scriptengine/tasks/base/context.py
+++ b/scriptengine/tasks/base/context.py
@@ -58,6 +58,12 @@ class ContextFrom(Task):
 
         if dict_arg:
             self.log_info(f"Context update from dict: {dict_arg}")
+            if not isinstance(dict_arg, dict):
+                self.log_error(
+                    "The 'dict' argument must be a dictionary "
+                    f"(was  a '{type(dict_arg).__name__}')"
+                )
+                raise ScriptEngineTaskRunError
             context_update_d = dict_arg
 
         elif file_arg:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setuptools.setup(
             "base.chdir = scriptengine.tasks.base.chdir:Chdir",
             "base.command = scriptengine.tasks.base.command:Command",
             "base.context = scriptengine.tasks.base.context:Context",
+            "base.context.from = scriptengine.tasks.base.context:ContextFrom",
             "base.copy = scriptengine.tasks.base.file:Copy",
             "base.echo = scriptengine.tasks.base.echo:Echo",
             "base.exit = scriptengine.tasks.base.exit:Exit",

--- a/tests/tasks/base/test_context.py
+++ b/tests/tasks/base/test_context.py
@@ -51,3 +51,94 @@ def test_context_simple_set():
     ctx += ctx_upd
     assert ctx["foo"] == 1
     assert ctx["bar"] == 2
+
+
+def test_context_from_dict():
+    t = from_yaml(
+        """
+        base.context.from:
+            dict: {'foo': 1, 'bar': 2}
+        """
+    )
+    ctx = {}
+    ctx_upd = t.run(ctx)
+    ctx += ctx_upd
+    assert ctx["foo"] == 1
+    assert ctx["bar"] == 2
+
+
+def test_context_from_context_dict():
+    t1 = from_yaml(
+        """
+        base.context:
+            update:
+                foo: 1
+                bar: 2
+        """
+    )
+    t2 = from_yaml(
+        """
+        base.context.from:
+            dict: '{{update}}'
+        """
+    )
+    ctx = {}
+    ctx_upd = t1.run(ctx)
+    ctx += ctx_upd
+    ctx_upd = t2.run(ctx)
+    ctx += ctx_upd
+    assert ctx["foo"] == 1
+    assert ctx["bar"] == 2
+
+
+def test_context_update_from_context_dict():
+    t1 = from_yaml(
+        """
+        base.context:
+            update:
+                foo: 5
+        """
+    )
+    t2 = from_yaml(
+        """
+        base.context:
+            foo: 1
+            bar: 2
+        """
+    )
+    t3 = from_yaml(
+        """
+        base.context.from:
+            dict: '{{update}}'
+        """
+    )
+    ctx = {}
+    ctx_upd = t1.run(ctx)
+    ctx += ctx_upd
+    ctx_upd = t2.run(ctx)
+    ctx += ctx_upd
+    ctx_upd = t3.run(ctx)
+    ctx += ctx_upd
+    assert ctx["foo"] == 5
+    assert ctx["bar"] == 2
+
+
+def test_context_from_file(tmp_path):
+    f = tmp_path / "f.yml"
+    f.write_text(
+        """
+        foo: 1
+        bar: 2
+        """
+    )
+    t = from_yaml(
+        f"""
+        base.context.from:
+            file: {f}
+        """
+    )
+    ctx = {}
+    ctx_upd = t.run(ctx)
+    ctx += ctx_upd
+    assert ctx["foo"] == 1
+    assert ctx["bar"] == 2


### PR DESCRIPTION
This is a follow-up to #67, implementing the possibility to load context variables from a YAML file, but also allowing to update the context from a previously defined dictionary. The implementation provides the feature from #67 but follows a different approach, hence, a new PR.