### PR TITLE
Fix base.remove breaks without ignore_not_found

### DIFF
--- a/scriptengine/tasks/base/file/remove.py
+++ b/scriptengine/tasks/base/file/remove.py
@@ -46,8 +46,15 @@ class Remove(Task):
                 self.log_warning("Non-existing path, nothing to remove")
                 return
             else:
-                self.log_error("Non-existing path")
-                raise ScriptEngineTaskRunError
+                self.log_warning("Non-existing path")
+                self.log_warning(
+                    "Deprecation warning! base.remove has not found anything to "
+                    "delete but ignore_not_found was not true. In the future, "
+                    "this will lead to an error!"
+                )
+                return
+            #   self.log_error("Non-existing path")
+            #   raise ScriptEngineTaskRunError
 
         for path in (Path(p) for p in path_list):
             if path.is_dir():

--- a/tests/tasks/base/test_remove.py
+++ b/tests/tasks/base/test_remove.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -83,7 +84,7 @@ def test_remove_with_wildcard(tmp_path):
         assert (tmp_path / f).exists()
 
 
-def test_remove_ignore_not_found(tmp_path):
+def test_remove_ignore_not_found(tmp_path, caplog):
     os.chdir(tmp_path)
 
     from_yaml(
@@ -94,13 +95,23 @@ def test_remove_ignore_not_found(tmp_path):
         """
     ).run({})
 
-    with pytest.raises(ScriptEngineTaskRunError):
+    #   with pytest.raises(ScriptEngineTaskRunError):
+    #       from_yaml(
+    #           """
+    #           base.remove:
+    #               path: foo
+    #           """
+    #       ).run({})
+
+    with caplog.at_level(logging.WARNING, logger="se.task"):
         from_yaml(
             """
             base.remove:
                 path: foo
             """
         ).run({})
+
+    assert "Deprecation warning! base.remove has not found anything" in caplog.text
 
 
 def test_remove_permission_denied(tmp_path):


### PR DESCRIPTION
Prior to version 0.14.0 the following task

```yaml
base.remove:
  path: foo
```
would write a warning (i.e. no error) if `foo` did not exist.

From 0.14.0, more specifically #78, an error occurs unless the optional argument `ignore_not_found` is given as true.

This breaks old scripts that may rely on the previous behaviour.

`base.remove` should follow the previous behaviour (i.e. warning, not error), but additionally write a deprecation warning.