### PR TITLE
Fix #64: deepdiff upgrade

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Internal changes
 ----------------
 - Base package build on pyproject.toml (#80)
 - #82: Use ubuntu-20.04 in Github actions (keep Python3.6 support)
+- #64: Require deepdiff 6.2.2
 
 
 ScriptEngine 0.14.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
     dependencies = [
         "python-dateutil",
         "deepmerge",
-        "deepdiff>=5.7.0,<6.2.0",
+        "deepdiff>=6.2.2",
         "PyYAML",
         "jinja2",
     ]


### PR DESCRIPTION
#64 has been solved upstream with seperman/deepdiff#356 and DeepDiff 6.2.2 has been released.