### PR TITLE
Use ubuntu-20.04 in Github actions (Python3.6 support)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   build-n-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]

--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-n-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout
@@ -33,7 +33,7 @@ jobs:
 
   test-from-pypi:
     needs: build-n-publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout
@@ -28,7 +28,7 @@ jobs:
           flake8 --exit-zero --count --statistics --exclude=__init__.py --max-line-length=88 scriptengine/
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
@@ -53,7 +53,7 @@ jobs:
 
   coverage:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Next release
 Internal changes
 ----------------
 - Base package build on pyproject.toml (#80)
+- #82: Use ubuntu-20.04 in Github actions (keep Python3.6 support)
 
 
 ScriptEngine 0.14.2


### PR DESCRIPTION
The `ubuntu-latest` version has changed from 20.04 to 22.04 for Github actions. This new image version drops the support for Python 3.6 and can therefore not be used any longer if we do not drop 3.6 ourselves. See actions/setup-python#544 for a longer discussion.

So the options are either to drop Python3.6 support for ScriptEngine or use `ubuntu-20.04` (instead of latest) for the Github actions.