### PR TITLE
Prevent base.getenv from failing when environment variable does not exist

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Next release
 ============
 
+Fixes
+-----
+- #83: Prevent base.getenv from failing when environment variable does not exist
+
 Internal changes
 ----------------
 - Base package build on pyproject.toml (#80)

--- a/docs/sphinx/base-tasks.rst
+++ b/docs/sphinx/base-tasks.rst
@@ -273,6 +273,9 @@ for example::
     - base.echo:
         msg: "I am {{ name }} and {{ home }} is my castle."
 
+When a requested environment variable does not exist, a warning is given and no
+corresponding context changes are made.
+
 .. warning::
    Only simple, non-nested context parameters (without dots) can be used in
    ``base.getenv``

--- a/scriptengine/tasks/base/envvars.py
+++ b/scriptengine/tasks/base/envvars.py
@@ -21,16 +21,19 @@ class Getenv(Task):
 
     @timed_runner
     def run(self, context):
-        vars_ = {
-            n: os.environ[self.getarg(n, context)]
-            for n in vars(self)
-            if not n.startswith("_")
+        wanted = {
+            n: self.getarg(n, context) for n in vars(self) if not n.startswith("_")
         }
         self.log_info(
-            "Read environment variables into context " f'({", ".join(vars_.keys())})'
+            f"Read environment variables to context: {', '.join(wanted.values())}"
         )
-        self.log_debug(vars_)
-        return ContextUpdate(vars_)
+        valid = {}
+        for n, v in wanted.items():
+            try:
+                valid[n] = os.environ[v]
+            except KeyError:
+                self.log_warning(f"Environment variable {v} does not exist")
+        return ContextUpdate(valid)
 
 
 class Setenv(Task):

--- a/tests/tasks/base/test_envvars.py
+++ b/tests/tasks/base/test_envvars.py
@@ -2,6 +2,7 @@ import os
 
 import yaml
 
+from scriptengine.engines import SimpleScriptEngine
 from scriptengine.yaml.parser import parse
 
 
@@ -33,3 +34,16 @@ def test_getenv():
     ctxt_upd = t.run(ctxt)
     ctxt += ctxt_upd
     assert ctxt["foo"] == "foo"
+
+
+def test_getenv_not_exists():
+    t = _from_yaml(
+        """
+        base.getenv:
+            bar: BAR
+        """
+    )
+    ctxt = {}
+    ctxt_upd = t.run(ctxt)
+    ctxt += ctxt_upd
+    assert "bar" not in ctxt


### PR DESCRIPTION
```yaml
base.getenv:
  foo: FOO
```
will fail with an uncatched `KeyError` if the environment variable `FOO` does not exist.

What should happen: Write a warning and do not set `foo` in the context.