### PR TITLE
base.command fails if ignore_error is true

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Next release
 Fixes
 -----
 - #83: Prevent base.getenv from failing when environment variable does not exist
+- #84: base.command fails if ignore_error is true
 
 Internal changes
 ----------------

--- a/scriptengine/tasks/base/command.py
+++ b/scriptengine/tasks/base/command.py
@@ -111,6 +111,7 @@ class Command(Task):
             f'{stderr_mode if stderr_mode in (True, False) else "context"}'
         )
         with log_pipe(stdout_mode) as stdout, log_pipe(stderr_mode) as stderr:
+            context_update = {}
             try:
                 cmd_proc = subprocess.run(
                     map(str, (command, *args)),
@@ -127,7 +128,6 @@ class Command(Task):
                     self.log_error(f"Command returned error code {e.returncode}")
                     raise ScriptEngineTaskRunError
             else:
-                context_update = {}
                 if isinstance(stdout_mode, str):
                     context_update[stdout_mode] = cmd_proc.stdout.split("\n")
                 if isinstance(stderr_mode, str):

--- a/tests/tasks/base/test_command.py
+++ b/tests/tasks/base/test_command.py
@@ -1,0 +1,51 @@
+import logging
+import os
+
+import yaml
+
+import scriptengine.logging
+from scriptengine.yaml.parser import parse
+
+
+def from_yaml(string):
+    return parse(yaml.load(string, Loader=yaml.SafeLoader))
+
+
+def test_command_ls(tmp_path, caplog):
+
+    os.chdir(tmp_path)
+    (tmp_path / "foo").touch()
+
+    caplog.clear()
+    scriptengine.logging.configure(logging.INFO)
+    logger = logging.getLogger("se.task")
+    logger.propagate = True
+
+    from_yaml(
+        """
+        base.command:
+          name: ls
+          args: [ foo ]
+        """
+    ).run({})
+    assert ("se.task", logging.INFO, "foo") in caplog.record_tuples
+
+
+def test_command_ls_not_exists(tmp_path, caplog):
+
+    os.chdir(tmp_path)
+
+    caplog.clear()
+    scriptengine.logging.configure(logging.INFO)
+    logger = logging.getLogger("se.task")
+    logger.propagate = True
+
+    from_yaml(
+        """
+        base.command:
+          name: ls
+          args: [ bar ]
+          ignore_error: true
+        """
+    ).run({})
+    assert "Command returned error code " in caplog.text


### PR DESCRIPTION
```yaml
  base.command:
    name: ls
    args: [ foo ]
    ignore_error: true
```
will fail with an uncatched `UnboundLocalError` if no file `foo` exists. This does not happen when `ignore_error` is not `true` (or not set).