### PR TITLE
Installation from package fails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,14 @@ Next release
 [...]
 
 
+ScriptEngine 0.14.4
+===================
+
+Fixes
+-----
+- #86: Installation from package fails
+
+
 ScriptEngine 0.14.3
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
     name = "scriptengine"
-    version = "0.14.3"
+    version = "0.14.4"
     authors = [{ name = "Uwe Fladrich", email = "uwe.fladrich@protonmail.com" }]
     description = "A lightweight and extensible framework for executing scripts written in YAML"
     readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
         # pyproject.toml. Hence, we have to keep this redundancy until
         # ScriptEngine drops support for Python 3.6
         name="scriptengine",
-        version="0.14.3",
+        version="0.14.4",
         install_requires=[
             "python-dateutil",
             "deepmerge",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ if __name__ == "__main__":
         # ScriptEngine drops support for Python 3.6
         name="scriptengine",
         version="0.14.3",
-        packages=["scriptengine"],
         install_requires=[
             "python-dateutil",
             "deepmerge",


### PR DESCRIPTION
When installing SE from package via setuptools, it fails with
```
se
Traceback (most recent call last):
  File "[...]/bin/se", line 5, in <module>
    from scriptengine.cli.se import main
ModuleNotFoundError: No module named 'scriptengine.cli'
```