### PR TITLE
Update deepdiff dependencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,9 @@
 Next release
 ============
 
-[...]
+Fixes
+-----
+- #87: Update deepdiff dependencies
 
 
 ScriptEngine 0.14.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
     dependencies = [
         "python-dateutil",
         "deepmerge",
-        "deepdiff>=6.2.2",
+        "deepdiff>=5.7.0,!=6.2.0,!=6.2.1",
         "PyYAML",
         "jinja2",
     ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
         install_requires=[
             "python-dateutil",
             "deepmerge",
-            "deepdiff>=5.7.0,<6.2.0",
+            "deepdiff>=5.7.0,!=6.2.0,!=6.2.1",
             "PyYAML",
             "jinja2",
         ],


### PR DESCRIPTION
Dependencies are inconsistent between `pyproject.toml` and `setup.py` at the moment:
```
# setup.py
"deepdiff>=5.7.0,<6.2.0",
# pyproject.toml
"deepdiff>=6.2.2",
```