### PR TITLE
Fix typos in docs and sources

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Next release
 Fixes
 -----
 - #87: Update deepdiff dependencies
+- #89: Fix typos in sources and docs (thanks @kinow)
 
 
 ScriptEngine 0.14.4

--- a/docs/sphinx/base-tasks.rst
+++ b/docs/sphinx/base-tasks.rst
@@ -132,7 +132,7 @@ values from a YAML file::
     - base.context.from:
         file: data.yml
 
-When running the scripte with ``se script.yml``, the context will contain
+When running the script with ``se script.yml``, the context will contain
 ``foo==4`` and ``bar==5``, provided that the file ``data.yml`` can be found in
 the current directory.
 
@@ -318,7 +318,7 @@ The ScriptEngine base task package provides tasks to create, copy/move/link and
 remove files and directories, as described in detail below in this section.
 
 Whenever it makes sense, the tasks will accept as their argument values single
-file or directory names, as well as YAML lists of such. Furhtermore, instead of
+file or directory names, as well as YAML lists of such. Furthermore, instead of
 full names, also Unix shell wildcard expressions are accepted.
 
 
@@ -462,7 +462,7 @@ This task can be used to find files or directories in the file system::
         depth: <NUMBER>  # optional, default -1
         set: <CONTEXT_PARAMETER>  # optional, default "result"
 
-Files and directories are searched starting at ``path`` and decending at most
+Files and directories are searched starting at ``path`` and descending at most
 ``depth`` levels down the directory hierarchy. If ``depth`` is less than zero,
 no limit is used for the search. Files and directories are matched against the
 Unix shell-style wildcards ``pattern``, which may include:

--- a/docs/sphinx/cli.rst
+++ b/docs/sphinx/cli.rst
@@ -31,7 +31,7 @@ flag:
     base.include, base.link, base.make_dir, base.move, base.remove,
     base.task_timer, base.template, base.time
 
-Using the ``-V`` or ``--version`` option displayes the current ScriptEngine version:
+Using the ``-V`` or ``--version`` option displays the current ScriptEngine version:
 
 .. code-block:: shell
 

--- a/docs/sphinx/concepts.rst
+++ b/docs/sphinx/concepts.rst
@@ -1,7 +1,7 @@
 Concepts
 ========
 
-Working with ScriptEngine does not require knowledge about it's underlying
+Working with ScriptEngine does not require knowledge about its underlying
 implementation architecture in detail, but it is useful to understand a few
 basic concepts and terms. It is, for example, good to know how `tasks` and
 `scripts` are understood in the ScriptEngine world. Furthermore, a few
@@ -20,8 +20,8 @@ Tasks "do things". This can be simple things, like copying a file or writing
 a message on the terminal. It could also be more complex things, involving
 more complex computations, file operations, or interactions with services.
 But whatever the actual complexity of a task is, it will be hidden. A task is
-listed in a script by it's name and some arguments, and later it is run by a
-ScriptEngine instance to do it's actual work.
+listed in a script by its name and some arguments, and later it is run by a
+ScriptEngine instance to do its actual work.
 
 A number of different tasks are available when using ScriptEngine. In fact, one
 of the main ideas with ScriptEngine is that it should be easy to develop and
@@ -47,7 +47,7 @@ Similar to tasks, `jobs` are units of work for ScriptEngine. Jobs can extend
 tasks in two ways:
 
     * jobs can join a number of tasks into a sequence, and
-    * jobs can add contitionals and loops to tasks.
+    * jobs can add conditionals and loops to tasks.
 
 Corresponding to these two cases, jobs use the special ``do`` keyword to specify
 sequences of tasks (see :ref:`scripts:Do`), and/or ``when`` or ``loop`` clauses
@@ -113,7 +113,7 @@ Usually, the context will be populated with information as tasks are processed.
 
 We have already seen the usage of the context in the "Hello world" example
 above. The ``context`` task stored a parameter named ``planet`` in the context
-and the ``echo`` task used the information from the context to display it's
+and the ``echo`` task used the information from the context to display its
 message.
 
 Since the context is a Python dictionary, it can store any Python data types.

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -12,14 +12,14 @@ default Python installation, run:
     > python --version
 
 If the version is 3.6 or larger, everything is fine. If the default Python
-version is 2, check if Python3 is still avalable:
+version is 2, check if Python3 is still available:
 
 .. code-block:: shell
 
     > python3 --version
 
-If that returns a verison >=3.6, you need to specify the Python3 interpreter
-explicitely in the installation below.
+If that returns a version >=3.6, you need to specify the Python3 interpreter
+explicitly in the installation below.
 
 
 Install in a Python Virtual Environment
@@ -51,7 +51,7 @@ Activate the created virtual environment:
 
 The ``venv`` module will also install the ``pip`` package manager in the
 virtual environment. Once the virtual environment is activated, use ``pip`` to
-install ScriptEngine, along with it's dependencies, from the Python Package
+install ScriptEngine, along with its dependencies, from the Python Package
 Index (PyPI_):
 
 .. code-block:: shell
@@ -111,7 +111,7 @@ from a clone of the Github repository:
     (.se)> cd scriptengine
     (.se)> pip install -e .
 
-This will install ScriptEngine along with it's dependencies very similar to
+This will install ScriptEngine along with its dependencies very similar to
 installing from PyPI. However, any changes made in the local directory will
 immediately affect the ScriptEngine installation.
 

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -32,7 +32,7 @@ developed because it met almost, but not quite, the needs of the author. Here
 are some important differences:
 
 - Tasks are executed on a single host, often the host where the ScriptEngine
-  command line tool is runnning. This is not an implication of any ScriptEngine
+  command line tool is running. This is not an implication of any ScriptEngine
   concept, though. It would be possible to implement ScriptEngine instances
   that execute tasks remotely, or on multiple hosts.
 

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -25,7 +25,7 @@ ScriptEngine will run the ``exit`` task and, well, exit. Technically, the script
 contains the YAML dictionary ``{exit: null}``, which will be parsed by
 ScriptEngine into the ``exit`` task.
 
-Let't look at a slightly more useful example::
+Let's look at a slightly more useful example::
 
     base.echo:
         msg: Hello, world!
@@ -97,14 +97,14 @@ The list can also be specified in a separate ``base.context`` task, as in::
 Note that the string defining the loop list must be enclosed in quotes because
 of the braces.
 
-In all of the above examples, the loop index variable was not explicitely
-named, which means it takes on it's default name, ``item``. The ``item``
+In all of the above examples, the loop index variable was not explicitly
+named, which means it takes on its default name, ``item``. The ``item``
 variable is added to the context for all jobs or tasks within the loop and can
 be accessed using the usual syntax, as shown in the previous examples. After
 the loop is completed, the variable is removed from the context, i.e. it is
 *not* possible to access it from jobs or tasks that follow the loop.
 
-It is possible to explicitely
+It is possible to explicitly
 define another name to the loop index variable, by using an extended loop
 specifier. Here is an example::
 
@@ -118,7 +118,7 @@ In that example, the loop index variable is named ``foo`` and it is added to
 the context of all jobs and tasks defined in the loop, in the same manner as
 the default ``item`` variable.
 
-In case a loop variable (explicitely given or ``item``, by default) already
+In case a loop variable (explicitly given or ``item``, by default) already
 exists in the context when a loop is entered, ScriptEngine will issue a warning
 about a colliding loop index variable. Nevertheless, the loop will still be
 processed, with the loop variable value *hiding* the value of the variable with
@@ -137,7 +137,7 @@ It is also possible to nest loops::
       with: bar
       in:   [4,5,6]
 
-In most cases, it will make sense to explicitely define the name of the loop
+In most cases, it will make sense to explicitly define the name of the loop
 index variables in nested loops, although it *is* possible to rely on the
 default variables. So the following example would work::
 
@@ -149,7 +149,7 @@ default variables. So the following example would work::
 
 Nevertheless, ScriptEngine will, again, issue a warning about a loop index
 variable collision. When using nested loops with the same loop index variable
-(explicitely or by default), the variable values from outer loops will not be
+(explicitly or by default), the variable values from outer loops will not be
 accessible in the inner loops.
 
 It is also possible to loop over dicts in ScriptEngine, like in the following
@@ -170,10 +170,10 @@ which would yield::
     Paul is 39 years old.
 
 The example shows that the extended loop specifier with ``in:`` must be used
-when looping over dicts, otherwise an *invalid loop decriptor error* error
-occurs. Futhermore, the example shows that the default loop variables for loops
+when looping over dicts, otherwise an *invalid loop descriptor error* error
+occurs. Furthermore, the example shows that the default loop variables for loops
 over dicts are ``key`` and ``value``. If the dict loop should use other
-variables, their names can be given explicitely::
+variables, their names can be given explicitly::
 
     - base.echo:
         msg: "{{name}} is {{age}} years old."
@@ -219,7 +219,7 @@ condition, by using a ``when`` clause. Here is an example::
           base.echo:
             msg: 'Peter, Paul and Mary most famous song'
 
-    Some might find it easier to read if the condition preceeds the task body.
+    Some might find it easier to read if the condition precedes the task body.
 
 The ``when`` clause can be combined with the ``do`` keyword, to execute a
 sequence of tasks conditionally::
@@ -279,7 +279,7 @@ To avoid parsing of an argument, use the ``!noparse`` YAML constructor::
     last_name: Bar
     full_name: !noparse "{{first_name}} {{last_name}}"
 
-which assignes the argument string ``{{first_name}} {{last_name}}`` literally
+which assigns the argument string ``{{first_name}} {{last_name}}`` literally
 to ``full_name`` and delays parsing until later, when ``first_name`` and
 ``last_name`` are available from the context.
 
@@ -330,7 +330,7 @@ Multi-line strings
 ^^^^^^^^^^^^^^^^^^
 Multi-line strings are defined in YAML and not a special feature of
 ScriptEngine. They can be useful for writing scripts by allowing to split
-long strings and make scripte more readable, or make it possible to format
+long strings and make script more readable, or make it possible to format
 output.
 This is an example for using multi-line strings to format output::
 
@@ -395,7 +395,7 @@ basename
 
 
 dirname
-    Returns the directory part of a path (i.e. the parth with the base name
+    Returns the directory part of a path (i.e. the part with the base name
     removed)::
 
         - base.context:

--- a/docs/tutorial/tutorial.yml
+++ b/docs/tutorial/tutorial.yml
@@ -4,7 +4,7 @@
 # The ScriptEngine tutorial file
 # -------------------------------------------------------------------------------------------------
 # This tutorial file is about using the ScriptEngine via the 'se' command and Yaml files.
-# It explaines (most of) the features implemented in ScriptEngine/se. Read it, run it
+# It explains (most of) the features implemented in ScriptEngine/se. Read it, run it
 # ('se tutorial.yml'), play around with it and enjoy using ScriptEngine!
 # =================================================================================================
 
@@ -120,7 +120,7 @@
 # Composite jobs
 # -------------------------------------------------------------------------------------------------
 
-# Jobs can be grouped by using *do*, which is usefull when when you want to apply *loop*s or *when*
+# Jobs can be grouped by using *do*, which is useful when you want to apply *loop*s or *when*
 # clauses to multiple tasks/jobs
 - do:
     - base.echo: {msg: "We can do something with '{{item}}'"}

--- a/scriptengine/cli/se.py
+++ b/scriptengine/cli/se.py
@@ -1,7 +1,7 @@
 """ScriptEngine command line interface (cli).
 
 The se command provides a command line interface to ScriptEngine, allowing for
-the creation of scripts from YAML files and runnig the scripts via the
+the creation of scripts from YAML files and running the scripts via the
 SimpleScriptEngine.
 """
 

--- a/scriptengine/exceptions.py
+++ b/scriptengine/exceptions.py
@@ -15,7 +15,7 @@ class ScriptEngineParseError(ScriptEngineError):
 
 
 class ScriptEngineParseFileError(ScriptEngineParseError):
-    """An file error while acessing an SE script"""
+    """An file error while accessing an SE script"""
 
 
 class ScriptEngineParseJinjaError(ScriptEngineParseError):

--- a/scriptengine/helpers/terminal_colors.py
+++ b/scriptengine/helpers/terminal_colors.py
@@ -1,4 +1,4 @@
-"""ScripteEngine helpers: Colored terminal output
+"""ScriptEngine helpers: Colored terminal output
 
 Terminal markup and colors by using ANSI escape sequences. To print colored
 text, use, for example:

--- a/scriptengine/tasks/base/envvars.py
+++ b/scriptengine/tasks/base/envvars.py
@@ -39,7 +39,7 @@ class Getenv(Task):
 class Setenv(Task):
     """Setenv task, sets environment variables from context.
     Setenv.run() takes the list of argument name, value pairs, and sets the
-    environemt variables given by the argument names to the values given by the
+    environment variables given by the argument names to the values given by the
     argument values. For example,
         base.setenv:
             foo: one

--- a/scriptengine/tasks/core/loader.py
+++ b/scriptengine/tasks/core/loader.py
@@ -5,7 +5,7 @@ import functools
 from scriptengine.exceptions import ScriptEngineTaskLoaderError
 
 
-# The load function goest through entry points, searching for ScriptEngine
+# The load function goes through entry points, searching for ScriptEngine
 # tasks. Since the function can be called quite frequently and modules are
 # *usually* not loaded while SE is run, the result is cached.
 # Note that this means that dynamic module is *not supported* by the loading

--- a/scriptengine/yaml/parser.py
+++ b/scriptengine/yaml/parser.py
@@ -50,7 +50,7 @@ yaml.add_constructor("!rrule", rrule_constructor)
 
 
 def parse(data):
-    """Recursively parses data and returns a ScriptEnginge Task or Job, or a list of those.
+    """Recursively parses data and returns a ScriptEngine Task or Job, or a list of those.
     The data is supposed to come from YAML-parsing a ScriptEngine script."""
 
     def build_job(todo, spec):


### PR DESCRIPTION
Hello, I learned about ScriptEngine yesterday at a meeting in the BSC, and started reading the docs last night. I found a couple of typos, so ran the IDE linter over the docs & sources. Let me know if there's any edit in this pull request that is incorrect, and I will edit the commit correcting it.

Cheers,
-Bruno