### PR TITLE
Add and install optional/extra dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,8 +45,7 @@ jobs:
         name: Install Dependencies and ScriptEngine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --editable .
-          python -m pip install pytest
+          python -m pip install --editable .[tests]
       -
         name: Run pytest
         run: pytest
@@ -67,10 +66,7 @@ jobs:
         name: Install Dependencies and ScriptEngine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --editable .
-          python -m pip install pytest
-          python -m pip install coverage
-          python -m pip install coveralls
+          python -m pip install --editable .[tests]
       -
         name: Run coverage
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,22 @@
         "jinja2",
     ]
 
+    [project.optional-dependencies]
+        tests = [
+            "coverage",
+            "coveralls",
+            "pytest"
+        ]
+
+        docs = [
+            "sphinx",
+            "sphinx-rtd-theme"
+        ]
+
+        all = [
+            "scriptengine[tests,docs]"
+        ]
+
     [project.urls]
         "Homepage" = "https://github.com/uwefladrich/scriptengine"
         "Bug Tracker" = "https://github.com/uwefladrich/scriptengine/issues"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 import setuptools
 
 if __name__ == "__main__":
+    tests = [
+        "coverage",
+        "coveralls",
+        "pytest"
+    ]
+    docs = [
+        "sphinx",
+        "sphinx-rtd-theme"
+    ]
     setuptools.setup(
         # The information below is duplicated from pyproject.toml.
         # This is because, for Python 3.6, we are stuck with older versions of
@@ -16,6 +25,11 @@ if __name__ == "__main__":
             "PyYAML",
             "jinja2",
         ],
+        extras_require={
+            "tests": tests,
+            "docs": docs,
+            "all": tests + docs
+        },
         entry_points={
             "console_scripts": [
                 "se = scriptengine.cli.se:main",


### PR DESCRIPTION
Hi,

I think this fixes #31 

When running the IDE linter/inspection for #89 , I noticed it complained about `pytest` missing in my venv (when it scanned some test files).

Then I saw #31, and quickly put up together something that I think works for `pyproject.toml` and `setup.*`. I used an older version of [Cylc](https://github.com/cylc/cylc-flow/blob/8.0a1/setup.py) to remember the old syntax and update the `setup.py` file. And used [`pyflow`](https://github.com/ecmwf/pyflow/blob/master/setup.cfg) and some [blog](https://hynek.me/articles/python-recursive-optional-dependencies/) to update the `pyproject.toml` file.

I have Python 3.10, so to test it I did something like:

```bash
$ rm -rf venv && python -m venv venv && source venv/bin/activate
$ pip install -e .
# here we have scriptengine base deps
$ pip install -e .[tests]
$ # now we have pytest and any other test dependency
$ pip install -e .[all]
$ # now we have everything, including the Sphinx dependencies
```

Then, in order to test the `setup.py` file, kept for Python 3.6 compatibility, I tried the simplest approach I could think of :grimacing: 

```bash
$ deactivate
$ rm -rf venv && python -m venv venv && source venv/bin/activate
$ mv pyproject.toml temp
$ # repeat tests
```

Cheers,
Bruno