### PR TITLE
Drop legacy task names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,16 @@
 Next release
 ============
 
-IMPORTANT: This release will drop Python3.6 support! (#88, #95)
+IMPORTANT NOTES:
+
+1. This release will drop Python3.6 support! (#88, #95)
+2. This release will drop support for legacy task names! (#96)
+
+
+Features
+--------
+- #96: Drop legacy task names
+
 
 Fixes
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,27 +38,6 @@ all = ["scriptengine[tests,docs]"]
 se = "scriptengine.cli.se:main"
 
 [project.entry-points."scriptengine.tasks"]
-# Legacy task names, deprecated
-"chdir" = "scriptengine.tasks.base.chdir:Chdir"
-"command" = "scriptengine.tasks.base.command:Command"
-"context" = "scriptengine.tasks.base.context:Context"
-"context.from" = "scriptengine.tasks.base.context:ContextFrom"
-"copy" = "scriptengine.tasks.base.file.copy:Copy"
-"echo" = "scriptengine.tasks.base.echo:Echo"
-"exit" = "scriptengine.tasks.base.exit:Exit"
-"find" = "scriptengine.tasks.base.find:Find"
-"getenv" = "scriptengine.tasks.base.envvars:Getenv"
-"include" = "scriptengine.tasks.base.include:Include"
-"link" = "scriptengine.tasks.base.file.link:Link"
-"make_dir" = "scriptengine.tasks.base.file.make_dir:MakeDir"
-"move" = "scriptengine.tasks.base.file.move:Move"
-"remove" = "scriptengine.tasks.base.file.remove:Remove"
-"setenv" = "scriptengine.tasks.base.envvars:Setenv"
-"task_timer" = "scriptengine.tasks.base.task_timer:TaskTimer"
-"template" = "scriptengine.tasks.base.template:Template"
-"time" = "scriptengine.tasks.base.time:Time"
-#
-# Valid task names
 "base.chdir" = "scriptengine.tasks.base.chdir:Chdir"
 "base.command" = "scriptengine.tasks.base.command:Command"
 "base.context" = "scriptengine.tasks.base.context:Context"

--- a/setup.py
+++ b/setup.py
@@ -25,24 +25,6 @@ if __name__ == "__main__":
                 "se = scriptengine.cli.se:main",
             ],
             "scriptengine.tasks": [
-                # Legacy task names, deprecated
-                "chdir = scriptengine.tasks.base.chdir:Chdir",
-                "command = scriptengine.tasks.base.command:Command",
-                "context = scriptengine.tasks.base.context:Context",
-                "copy = scriptengine.tasks.base.file.copy:Copy",
-                "echo = scriptengine.tasks.base.echo:Echo",
-                "exit = scriptengine.tasks.base.exit:Exit",
-                "find = scriptengine.tasks.base.find:Find",
-                "include = scriptengine.tasks.base.include:Include",
-                "link = scriptengine.tasks.base.file.link:Link",
-                "make_dir = scriptengine.tasks.base.file.make_dir:MakeDir",
-                "move = scriptengine.tasks.base.file.move:Move",
-                "remove = scriptengine.tasks.base.file.remove:Remove",
-                "task_timer = scriptengine.tasks.base.task_timer:TaskTimer",
-                "template = scriptengine.tasks.base.template:Template",
-                "time = scriptengine.tasks.base.time:Time",
-                #
-                # Valid task names
                 "base.chdir = scriptengine.tasks.base.chdir:Chdir",
                 "base.command = scriptengine.tasks.base.command:Command",
                 "base.context = scriptengine.tasks.base.context:Context",


### PR DESCRIPTION
Task names should be fully qualified by their task package namespace, e.g. ``base.context``, not ``context``.