### PR TITLE
Fix errors in base.command tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,7 @@ Fixes
 - #87: Update deepdiff dependencies
 - #89, #92, #93: Fix typos in sources and docs (thanks @kinow)
 - #90: Add and install optional/extra dependencies (thanks @kinow)
+- #98: Fix errors in base.command tests
 
 
 Internal changes

--- a/src/scriptengine/tasks/base/command.py
+++ b/src/scriptengine/tasks/base/command.py
@@ -124,12 +124,20 @@ class Command(Task):
             except subprocess.CalledProcessError as e:
                 if ignore_error:
                     self.log_warning(f"Command returned error code {e.returncode}")
+                    stdout = e.stdout
+                    stderr = e.stderr
                 else:
                     self.log_error(f"Command returned error code {e.returncode}")
                     raise ScriptEngineTaskRunError
             else:
-                if isinstance(stdout_mode, str):
-                    context_update[stdout_mode] = cmd_proc.stdout.split("\n")
-                if isinstance(stderr_mode, str):
-                    context_update[stderr_mode] = cmd_proc.stderr.split("\n")
+                stdout = cmd_proc.stdout
+                stderr = cmd_proc.stderr
+
+            if isinstance(stdout_mode, str):
+                self.log_debug(f"Store stdout in context under {stdout_mode}")
+                context_update[stdout_mode] = stdout.split("\n")
+            if isinstance(stderr_mode, str):
+                self.log_debug(f"Store stderr in context under {stderr_mode}")
+                context_update[stderr_mode] = stderr.split("\n")
+
         return context_update or None

--- a/tests/tasks/base/test_command.py
+++ b/tests/tasks/base/test_command.py
@@ -30,6 +30,8 @@ def test_command_ls(tmp_path, caplog):
 
 
 def test_command_ls_not_exists(tmp_path, caplog):
+    os.chdir(tmp_path)
+
     t = from_yaml(
         """
         base.command:

--- a/tests/tasks/base/test_command.py
+++ b/tests/tasks/base/test_command.py
@@ -13,20 +13,23 @@ def from_yaml(string):
 
 def test_command_ls(tmp_path, caplog):
     os.chdir(tmp_path)
-    (tmp_path / "foo").touch()
+    f = tmp_path / "foo"
+    f.touch()
     time.sleep(2)
 
     t = from_yaml(
-        """
+        f"""
         base.command:
           name: ls
-          args: [ foo ]
+          args: [ {f.name} ]
         """
     )
 
     with caplog.at_level(logging.INFO, logger="se.task"):
         t.run({})
         assert "foo" in [rec.message for rec in caplog.records]
+
+    f.unlink()
 
 
 def test_command_ls_not_exists(tmp_path, caplog):


### PR DESCRIPTION
There are issues with the way `base.command` is tested, when pytest is running these tests in Github actions. Tests fail because some of the lines that the tests are checking are not appearing in the log capture. The whole problem is not really reproducible, tests run fine locally and sometimes even on Github.