### PR TITLE
Require SE 1.0.0rc1 in Github action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies and ScriptEngine
         run: |
           python -m pip install --upgrade pip
-          python -m pip install scriptengine
+          python -m pip install "scriptengine>=1.0.0rc1"
       - name: Test run ScriptEngine cli (version)
         run: |
           se --version


### PR DESCRIPTION
This is a temporary requirement, until 1.0.0 is released. It is needed to make sure that the test uses the latest SE version.