### PR TITLE
Have base.task_timer return proper Context

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Fixes
 -----
 - #106, #108: Make base.time return proper Context (thanks @oloapinivad)
   (base.time did not work properly under "do")
+- #109: Have base.task_timer return proper Context
 
 
 ScriptEngine 1.0.0rc2

--- a/src/scriptengine/tasks/base/task_timer.py
+++ b/src/scriptengine/tasks/base/task_timer.py
@@ -58,6 +58,4 @@ class TaskTimer(Task):
             logging = False
             self.log_info("Task timing is switched off")
 
-        return Context(
-            {"se": {"tasks": {"timing": {"mode": mode, "logging": logging}}}}
-        )
+        return Context({"se.tasks.timing": {"mode": mode, "logging": logging}})

--- a/src/scriptengine/tasks/base/task_timer.py
+++ b/src/scriptengine/tasks/base/task_timer.py
@@ -1,30 +1,31 @@
 """TaskTimer for ScriptEngine."""
 
-from scriptengine.tasks.core import Task
 from scriptengine.exceptions import ScriptEngineTaskRunError
+from scriptengine.tasks.core import Task
 
 
 class TaskTimer(Task):
     """TaskTimer, controls ScriptEngine task timing feature
 
-       Arguments:
-         mode (required):   one of
-                            False:       Timing is switched off.
-                            'basic':     Each task is timed, log messages are
-                                         written according to 'logging'
-                                         argument.
-                            'classes':   As for 'basic', plus times are
-                                         accumulated for task classes.
-                            'instances': As for 'classes', plus times are
-                                         accumulated for each individual task
-                                         instance.
-        logging (optional): one of
-                            False:   No time logging after each task. Does not
-                                     affect statistic collection.
-                            'info':  Logging to the info logger.
-                            'debug': Logging to the debug logger.
+    Arguments:
+      mode (required):   one of
+                         False:       Timing is switched off.
+                         'basic':     Each task is timed, log messages are
+                                      written according to 'logging'
+                                      argument.
+                         'classes':   As for 'basic', plus times are
+                                      accumulated for task classes.
+                         'instances': As for 'classes', plus times are
+                                      accumulated for each individual task
+                                      instance.
+     logging (optional): one of
+                         False:   No time logging after each task. Does not
+                                  affect statistic collection.
+                         'info':  Logging to the info logger.
+                         'debug': Logging to the debug logger.
     """
-    _required_arguments = ('mode', )
+
+    _required_arguments = ("mode",)
 
     def __init__(self, arguments):
         TaskTimer.check_arguments(arguments)
@@ -32,25 +33,30 @@ class TaskTimer(Task):
 
     def run(self, context):
 
-        mode = self.getarg('mode', context)
-        if mode not in (False, 'basic', 'classes', 'instances'):
-            msg = ('Unknown mode in TaskTimer: must be one of "off", "basic", '
-                   f'"classes", "instances", not "{mode}"')
+        mode = self.getarg("mode", context)
+        if mode not in (False, "basic", "classes", "instances"):
+            msg = (
+                'Unknown mode in TaskTimer: must be one of "off", "basic", '
+                f'"classes", "instances", not "{mode}"'
+            )
             self.log_error(msg)
             raise ScriptEngineTaskRunError(msg)
 
         if mode:
-            logging = self.getarg('logging', context, default=False)
-            if logging not in (False, 'info', 'debug'):
-                msg = ('Unknown logging mode in TaskTimer: must be one of '
-                       f'"off", "info", "debug", not "{logging}"')
+            logging = self.getarg("logging", context, default=False)
+            if logging not in (False, "info", "debug"):
+                msg = (
+                    "Unknown logging mode in TaskTimer: must be one of "
+                    f'"off", "info", "debug", not "{logging}"'
+                )
                 self.log_error(msg)
                 raise ScriptEngineTaskRunError(msg)
-            self.log_info(f'Task timing activated in mode "{mode}" and '
-                          f'logging to "{logging}"')
+            self.log_info(
+                f'Task timing activated in mode "{mode}" and ' f'logging to "{logging}"'
+            )
         else:
             logging = False
-            self.log_info('Task timing is switched off')
+            self.log_info("Task timing is switched off")
 
-        context['se']['tasks']['timing']['mode'] = mode
-        context['se']['tasks']['timing']['logging'] = logging
+        context["se"]["tasks"]["timing"]["mode"] = mode
+        context["se"]["tasks"]["timing"]["logging"] = logging

--- a/src/scriptengine/tasks/base/task_timer.py
+++ b/src/scriptengine/tasks/base/task_timer.py
@@ -1,5 +1,6 @@
 """TaskTimer for ScriptEngine."""
 
+from scriptengine.context import Context
 from scriptengine.exceptions import ScriptEngineTaskRunError
 from scriptengine.tasks.core import Task
 
@@ -32,7 +33,6 @@ class TaskTimer(Task):
         super().__init__(arguments)
 
     def run(self, context):
-
         mode = self.getarg("mode", context)
         if mode not in (False, "basic", "classes", "instances"):
             msg = (
@@ -58,5 +58,6 @@ class TaskTimer(Task):
             logging = False
             self.log_info("Task timing is switched off")
 
-        context["se"]["tasks"]["timing"]["mode"] = mode
-        context["se"]["tasks"]["timing"]["logging"] = logging
+        return Context(
+            {"se": {"tasks": {"timing": {"mode": mode, "logging": logging}}}}
+        )

--- a/tests/tasks/base/test_task_timing.py
+++ b/tests/tasks/base/test_task_timing.py
@@ -42,25 +42,19 @@ def test_task_timing():
 
     context = Context(
         {
-            "se": {
-                "tasks": {
-                    "timing": {
-                        "mode": False,
-                        "logging": None,
-                        "timers": {},
-                    }
-                }
+            "se.tasks.timing": {
+                "mode": False,
+                "logging": None,
+                "timers": {},
             }
         }
     )
+
     context += timer.run(context)
     timed.run(context)
 
-    assert context["se"]["tasks"]["timing"]["mode"] == timer_mode
-    assert context["se"]["tasks"]["timing"]["logging"] == timer_logging
+    assert context["se.tasks.timing"]["mode"] == timer_mode
+    assert context["se.tasks.timing"]["logging"] == timer_logging
 
-    assert (
-        context["se"]["tasks"]["timing"]["timers"]["classes"][timed.__class__.__name__]
-        > 1.0
-    )
-    assert context["se"]["tasks"]["timing"]["timers"]["instances"][timed.id] > 1.0
+    assert context["se.tasks.timing.timers.classes"][timed.__class__.__name__] > 1.0
+    assert context["se.tasks.timing.timers.instances"][timed.id] > 1.0

--- a/tests/tasks/base/test_task_timing.py
+++ b/tests/tasks/base/test_task_timing.py
@@ -2,6 +2,7 @@ from time import sleep
 
 import pytest
 
+from scriptengine.context import Context
 from scriptengine.exceptions import ScriptEngineTaskArgumentMissingError
 from scriptengine.tasks.base.task_timer import TaskTimer
 from scriptengine.tasks.core import Task, timed_runner
@@ -39,18 +40,20 @@ def test_task_timing():
     timer = TaskTimer({"mode": timer_mode, "logging": timer_logging})
     timed = WaitASecond()
 
-    context = {
-        "se": {
-            "tasks": {
-                "timing": {
-                    "mode": False,
-                    "logging": None,
-                    "timers": {},
+    context = Context(
+        {
+            "se": {
+                "tasks": {
+                    "timing": {
+                        "mode": False,
+                        "logging": None,
+                        "timers": {},
+                    }
                 }
             }
         }
-    }
-    timer.run(context)
+    )
+    context += timer.run(context)
     timed.run(context)
 
     assert context["se"]["tasks"]["timing"]["mode"] == timer_mode


### PR DESCRIPTION
The `base.task_timer` task is not returning a proper `Context`.