### PR TITLE
Add loop-over-range example to docs (fixes #107)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+Next release
+============
+
+Fixes
+-----
+- #107: Add loop-over-range example to docs
+
+
 ScriptEngine 1.0.0rc3
 =====================
 

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -97,6 +97,17 @@ The list can also be specified in a separate ``base.context`` task, as in::
 Note that the string defining the loop list must be enclosed in quotes because
 of the braces.
 
+As the previous examples illustrate, the loop specifier must be a valid YAML list. There is,
+however, some freedom in the way that list is constructed. For example, a common pattern is to
+loop over a contiguous range of numbers. This can be accomplished by combining the Jinja
+``range()`` function and ``list`` filter::
+
+  - base.echo:
+      msg: "Looping from one to five, now at {{item+1}}"
+    loop: "{{range(5)|list}}"
+
+In general, it is often useful to use the power of Jinja in order to contruct loops.
+
 In all of the above examples, the loop index variable was not explicitly
 named, which means it takes on its default name, ``item``. The ``item``
 variable is added to the context for all jobs or tasks within the loop and can


### PR DESCRIPTION
Add a little example to the docs that explains how to loop over a range of numbers by using Jinja.