### PR TITLE
Update $PWD in environment for base.command processes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Fixes
 -----
 - #107: Add loop-over-range example to docs
 - #115: Fix: task timing in jobs does not work
+- #114: Update $PWD in environment for base.command processes
 
 
 ScriptEngine 1.0.0rc3

--- a/tests/tasks/base/test_command.py
+++ b/tests/tasks/base/test_command.py
@@ -51,3 +51,17 @@ def test_command_ls_not_exists(tmp_path, caplog):
             rec.message for rec in caplog.records
         ]
         assert len(c["ls_stderr"]) > 1
+
+
+def test_command_cwd_sets_pwd(tmp_path):
+    os.chdir(tmp_path)
+    t = from_yaml(
+        f"""
+        base.command:
+            name: env
+            cwd: {tmp_path}
+            stdout: env_output
+        """
+    )
+    c = t.run({})
+    assert f"PWD={tmp_path}" in c["env_output"]


### PR DESCRIPTION
When commands are executed via the `base.command` task, they generally inherit the environment from the `se` process. Since `se` is a Python script, some things work differently compared to shell scripts. One such thing is that `$PWD` is _not_ updated when `base.command` is run with the `cwd` argument, i.e. when the current working directory is changed. This is because Python does not behave like bash or other shells and `subprocess.Popen` is _not_ updating `$PWD`! Or seen the other way around, `$PWD` is a shell environment variable and `subprocess` does not fiddle with it (see, for example, [here](https://github.com/python/cpython/issues/48307)).

However, the `base.command` task it is often used to run shell scripts and therefore it is expected that `$PWD` is updated as it would in a shell. Thus, updating `$PWD` should be implemented in `base.command`.