### PR TITLE
Fix: task timing in jobs does not work

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Features
 Fixes
 -----
 - #107: Add loop-over-range example to docs
+- #115: Fix: task timing in jobs does not work
 
 
 ScriptEngine 1.0.0rc3

--- a/src/scriptengine/tasks/core/timing.py
+++ b/src/scriptengine/tasks/core/timing.py
@@ -1,30 +1,30 @@
 """ScriptEngine timing for tasks: provides timing of Task classes .run() method
 """
 
-import time
 import functools
+import time
 
 
 def timed_runner(func):
     """Wrapper for run() functions of SE tasks. To be used as decorator as follows:
 
-        from scriptengine.task_timing import timed_runner
-        class Foo(Task):
+    from scriptengine.task_timing import timed_runner
+    class Foo(Task):
+        # ...
+        @timed_runner
+        def run(self, context):
             # ...
-            @timed_runner
-            def run(self, context):
-                # ...
     """
 
     @functools.wraps(func)
     def wrap_timed(self, context):
 
         try:
-            mode = context['se']['tasks']['timing']['mode']
+            mode = context["se.tasks.timing.mode"]
         except KeyError:
             mode = False
 
-        if mode in ('basic', 'classes', 'instances'):
+        if mode in ("basic", "classes", "instances"):
 
             # timed function call
             start_tic = time.perf_counter()
@@ -32,21 +32,21 @@ def timed_runner(func):
             elapsed_time = time.perf_counter() - start_tic
 
             # logging
-            if context['se']['tasks']['timing']['logging'] == 'info':
-                self.log_info(f'Elapsed time: {elapsed_time:0.4f} seconds')
-            elif context['se']['tasks']['timing']['logging'] == 'debug':
-                self.log_debug(f'Elapsed time: {elapsed_time:0.4f} seconds')
+            if context["se.tasks.timing.logging"] == "info":
+                self.log_info(f"Elapsed time: {elapsed_time:0.4f} seconds")
+            elif context["se.tasks.timing.logging"] == "debug":
+                self.log_debug(f"Elapsed time: {elapsed_time:0.4f} seconds")
 
             # update timers
-            if mode in ('classes', 'instances'):
-                timers = context['se']['tasks']['timing']['timers']
+            if mode in ("classes", "instances"):
+                timers = context["se.tasks.timing.timers"]
 
-                class_t = timers.setdefault('classes', {})
+                class_t = timers.setdefault("classes", {})
                 class_t.setdefault(self.__class__.__name__, 0)
                 class_t[self.__class__.__name__] += elapsed_time
 
-                if mode == 'instances':
-                    instance_t = timers.setdefault('instances', {})
+                if mode == "instances":
+                    instance_t = timers.setdefault("instances", {})
                     instance_t.setdefault(self.id, 0)
                     instance_t[self.id] += elapsed_time
 

--- a/src/scriptengine/tasks/core/timing.py
+++ b/src/scriptengine/tasks/core/timing.py
@@ -19,10 +19,7 @@ def timed_runner(func):
     @functools.wraps(func)
     def wrap_timed(self, context):
 
-        try:
-            mode = context["se.tasks.timing.mode"]
-        except KeyError:
-            mode = False
+        mode = context.get("se.tasks.timing.mode")
 
         if mode in ("basic", "classes", "instances"):
 

--- a/tests/tasks/base/test_task_timing.py
+++ b/tests/tasks/base/test_task_timing.py
@@ -1,11 +1,18 @@
 from time import sleep
 
 import pytest
+import yaml
 
 from scriptengine.context import Context
 from scriptengine.exceptions import ScriptEngineTaskArgumentMissingError
+from scriptengine.tasks.base.echo import Echo
 from scriptengine.tasks.base.task_timer import TaskTimer
 from scriptengine.tasks.core import Task, timed_runner
+from scriptengine.yaml.parser import parse
+
+
+def from_yaml(string):
+    return parse(yaml.load(string, Loader=yaml.FullLoader))
 
 
 class WaitASecond(Task):
@@ -51,10 +58,54 @@ def test_task_timing():
     )
 
     context += timer.run(context)
-    timed.run(context)
+    context += timed.run(context)
 
     assert context["se.tasks.timing"]["mode"] == timer_mode
     assert context["se.tasks.timing"]["logging"] == timer_logging
 
     assert context["se.tasks.timing.timers.classes"][timed.__class__.__name__] > 1.0
     assert context["se.tasks.timing.timers.instances"][timed.id] > 1.0
+
+
+def test_task_timer_after_echo():
+
+    context = Context(
+        {
+            "se.tasks.timing": {
+                "mode": False,
+                "logging": None,
+                "timers": {},
+            }
+        }
+    )
+    context += TaskTimer({"mode": "classes"}).run(context)
+    context += Echo({"msg": "Hello!"}).run(context)
+
+    assert "se.tasks.timing.timers.classes" in context
+    assert context["se.tasks.timing.timers.classes.Echo"] > 0.0
+
+
+def test_task_timer_in_job():
+
+    context = Context(
+        {
+            "se.tasks.timing": {
+                "mode": False,
+                "logging": None,
+                "timers": {},
+            }
+        }
+    )
+    context += TaskTimer({"mode": "classes"}).run(context)
+
+    job = from_yaml(
+        """
+        do:
+            - base.echo:
+                msg: Hello
+        """
+    )
+    context += job.run(context)
+
+    assert "se.tasks.timing.timers.classes" in context
+    assert context["se.tasks.timing.timers.classes.Echo"] > 0.0


### PR DESCRIPTION
A simple script like the following will not work:
```yaml
- base.task_timer:
    mode: classes
- do:
    - base.echo:
        msg: Hello!
- base.echo:
    msg: "{{ se.tasks.timing.timers }}"
```
The effect is that `se.tasks.timing.timers` is empty, in particular, `se.tasks.timing.timers.classes` will not exist.

This is a regression with 1.0.0rc1.