### PR TITLE
Fix: ReadTheDocs does not build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,7 @@ build:
 
 sphinx:
   configuration: docs/sphinx/conf.py
+
+python:
+  install:
+    - requirements: docs/sphinx/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/sphinx/conf.py

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,9 @@
 Next release
 ============
 
-...
-
+Fixes
+-----
+- #117: Fix: ReadTheDocs does not build
 
 
 ScriptEngine 1.0.0rc4

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme >= 2.0.0


### PR DESCRIPTION
The automatic build and publish of ScriptEngine documentation on ReadTheDocs has been broken since a while back. No updated docs where published since September 2023.