### PR TITLE
incrdate filter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,10 @@
 Next release
 ============
 
-...
+Features
+--------
+- #119: New Jinja filter: increment_datetime (thanks @jmrgonza)
+
 
 
 ScriptEngine 1.0.0

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -382,6 +382,13 @@ datetime
         base.context:
             date_time: "{{ '2022/01/01 00:00:00' | datetime('%Y/%m/%d %H:%M:%S') }}""
 
+incrdate
+    Increment a ``datetime.datetime`` object by a number of days, hours, minutes
+    or seconds, for example::
+
+        base.context:
+            date_time: "{{ '2022-01-01 00:00:00' | datetime | incrdate(days=1, hours=6)}}""
+
 date
     Converts a string to a ``datetime.date`` object::
 

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -382,12 +382,12 @@ datetime
         base.context:
             date_time: "{{ '2022/01/01 00:00:00' | datetime('%Y/%m/%d %H:%M:%S') }}""
 
-incrdate
+increment_datetime
     Increment a ``datetime.datetime`` object by a number of days, hours, minutes
     or seconds, for example::
 
         base.context:
-            date_time: "{{ '2022-01-01 00:00:00' | datetime | incrdate(days=1, hours=6)}}""
+            date_time: "{{ '2022-01-01 00:00:00' | datetime | increment_datetime(days=1, hours=6)}}""
 
 date
     Converts a string to a ``datetime.date`` object::

--- a/src/scriptengine/jinja.py
+++ b/src/scriptengine/jinja.py
@@ -17,7 +17,7 @@ def string_to_date(string, format="%Y-%m-%d %H:%M:%S"):
     """Jinja2 filter to convert a string to datetime.date"""
     return datetime.datetime.strptime(string, format).date()
 
-def datetime_increment(dt, days=0, hours=0, minutes=0, seconds=0):
+def increment_datetime(dt, days=0, hours=0, minutes=0, seconds=0):
     """Jinja2 filter to increment datetime by a number of days/hours/minutes/seconds"""
     return dt + datetime.timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
 
@@ -46,7 +46,7 @@ def filters():
     return {
         "datetime": string_to_datetime,
         "date": string_to_date,
-        "incrdate": datetime_increment,
+        "increment_datetime": increment_datetime,
         "basename": basename,
         "dirname": dirname,
         "exists": exists,

--- a/src/scriptengine/jinja.py
+++ b/src/scriptengine/jinja.py
@@ -17,6 +17,9 @@ def string_to_date(string, format="%Y-%m-%d %H:%M:%S"):
     """Jinja2 filter to convert a string to datetime.date"""
     return datetime.datetime.strptime(string, format).date()
 
+def datetime_increment(dt, days=0, hours=0, minutes=0, seconds=0):
+    """Jinja2 filter to increment datetime by a number of days/hours/minutes/seconds"""
+    return dt + datetime.timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
 
 def basename(path):
     """Jinja2 filter that returns a path's base name"""
@@ -43,6 +46,7 @@ def filters():
     return {
         "datetime": string_to_datetime,
         "date": string_to_date,
+        "incrdate": datetime_increment,
         "basename": basename,
         "dirname": dirname,
         "exists": exists,

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -1,0 +1,143 @@
+from datetime import date, datetime
+
+import pytest
+import yaml
+
+from scriptengine.context import Context as SEContext
+from scriptengine.yaml.parser import parse
+
+
+def from_yaml(string):
+    return parse(yaml.load(string, Loader=yaml.FullLoader))
+
+
+@pytest.mark.parametrize("test_value", (1, 1.5, "a_string"))
+def test_jinja_no_filter(test_value):
+    context = SEContext(bar=test_value)
+    task = from_yaml("base.context: {foo: '{{ bar }}'}")
+    context += task.run(context)
+    assert context["foo"] == test_value
+
+
+@pytest.mark.parametrize(
+    ("test_value", "format", "expected"),
+    (
+        ("2024/01/01", "%Y/%m/%d", date(2024, 1, 1)),
+        ("2024-01-01", "%Y-%m-%d", date(2024, 1, 1)),
+        ("2024-01-01 00:00:00", "%Y-%m-%d %H:%M:%S", date(2024, 1, 1)),
+    ),
+)
+def test_jinja_string_to_date(test_value, format, expected):
+    context = SEContext()
+    task = from_yaml(
+        f"""base.context: {{foo: "{{{{ '{test_value}' | date('{format}') }}}}"}}"""
+    )
+    context += task.run(context)
+    assert context["foo"] == expected
+
+
+@pytest.mark.parametrize(
+    ("test_value", "format", "expected"),
+    (
+        ("2024-01-01", "%Y-%m-%d", datetime(2024, 1, 1)),
+        ("2024-01-01 00:00:00", "%Y-%m-%d %H:%M:%S", datetime(2024, 1, 1)),
+        ("2024-01-01 12:34:56", "%Y-%m-%d %H:%M:%S", datetime(2024, 1, 1, 12, 34, 56)),
+    ),
+)
+def test_jinja_string_to_datetime(test_value, format, expected):
+    context = SEContext()
+    task = from_yaml(
+        f"""base.context: {{foo: "{{{{ '{test_value}' | datetime('{format}') }}}}"}}"""
+    )
+    context += task.run(context)
+    assert context["foo"] == expected
+
+
+@pytest.mark.parametrize(
+    ("start", "days", "hours", "minutes", "expected"),
+    (
+        ("2024-01-01 00:00:00", 0, 0, 0, datetime(2024, 1, 1)),
+        ("2024-01-01 00:00:00", 1, 0, 0, datetime(2024, 1, 2)),
+        ("2024-01-01 00:00:00", 0, 1, 0, datetime(2024, 1, 1, 1, 0)),
+    ),
+)
+def test_jinja_filter_increment_datetime(start, days, hours, minutes, expected):
+    context = SEContext()
+    task = from_yaml(
+        f"""
+        base.context:
+            foo: "{{{{ '{start}' | datetime | increment_datetime(days={days}, hours={hours}, minutes={minutes}) }}}}"
+        """
+    )
+    context += task.run(context)
+    assert context["foo"] == expected
+
+
+@pytest.mark.parametrize(
+    ("test_value", "expected"),
+    (
+        ("foo", "foo"),
+        ("foo.txt", "foo.txt"),
+        ("/foo.txt", "foo.txt"),
+        ("/bar/foo.txt", "foo.txt"),
+        ("bar/foo.txt", "foo.txt"),
+        ("./foo.txt", "foo.txt"),
+    ),
+)
+def test_jinja_filter_basetime(test_value, expected):
+    context = SEContext(bar=test_value)
+    task = from_yaml("base.context: {foo: '{{ bar | basename }}'}")
+    context += task.run(context)
+    assert context["foo"] == expected
+
+
+@pytest.mark.parametrize(
+    ("test_value", "expected"),
+    (
+        ("foo", None),
+        ("foo.txt", None),
+        ("/foo.txt", "/"),
+        ("/bar/foo.txt", "/bar"),
+        ("bar/foo.txt", "bar"),
+        ("./foo.txt", "."),
+    ),
+)
+def test_jinja_filter_dirtime(test_value, expected):
+    context = SEContext(bar=test_value)
+    task = from_yaml("base.context: {foo: '{{ bar | dirname }}'}")
+    context += task.run(context)
+    assert context["foo"] == expected
+
+
+def test_jinja_filter_file_exist(tmp_path):
+    context = SEContext()
+    file = tmp_path / "foo.tmp"
+    file.touch()
+    task = from_yaml(f"""base.context: {{foo: "{{{{ '{file}' | exists }}}}"}}""")
+    context += task.run(context)
+    assert context["foo"] is True
+
+
+def test_jinja_filter_dir_exist(tmp_path):
+    context = SEContext()
+    directory = tmp_path / "foo"
+    directory.mkdir()
+    task = from_yaml(f"""base.context: {{foo: "{{{{ '{directory}' | exists }}}}"}}""")
+    context += task.run(context)
+    assert context["foo"] is True
+
+
+def test_jinja_filter_file_does_not_exist(tmp_path):
+    context = SEContext()
+    file = tmp_path / "foo.tmp"
+    task = from_yaml(f"""base.context: {{foo: "{{{{ '{file}' | exists }}}}"}}""")
+    context += task.run(context)
+    assert context["foo"] is False
+
+
+def test_jinja_filter_dir_does_not_exist(tmp_path):
+    context = SEContext()
+    directory = tmp_path / "foo"
+    task = from_yaml(f"""base.context: {{foo: "{{{{ '{directory}' | exists }}}}"}}""")
+    context += task.run(context)
+    assert context["foo"] is False


### PR DESCRIPTION
Implements and incrdate filter to enable manipulation of datetime objects in jinja2 templates.
This allows to add (or substract) a given number of days, hours, minutes or seconds to the datetime
upon which the filter is applied.