### PR TITLE
Add Jinja `render` filter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Next release
 Features
 --------
 - #119: New Jinja filter: increment_datetime (thanks @jmrgonza)
+- #122: New Jinja filter: render (solves #121)
 
 Internal changes
 ----------------

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -437,6 +437,23 @@ path_join
         base.echo:
             msg: "{{ ['foo', 'bar.txt'] | path_join }}"
 
+Other filters
+^^^^^^^^^^^^^
+
+render
+    Renders the expression (e.g. a variable) with Jinja2 and the current context. This can be used, for
+    example, to explicitly render context parameters that have been set with the `!noparse` tag::
+
+        - base.context:
+            foo: me
+            bar: !noparse "{{ foo }}"
+        - when "{{ bar|render == 'me' }}"
+          base.echo:
+            msg: "It is {{ bar }}!"
+
+    Without using the `render` filter in the example, the `when` clause would evaluate to `false` because
+    the value of `bar` would still be `"{{ foo }}"` because of `!noparse`.
+
 
 .. _PyYAML: https://pyyaml.org
 .. _RFC5545: https://tools.ietf.org/html/rfc5545

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -389,6 +389,9 @@ increment_datetime
         base.context:
             date_time: "{{ '2022-01-01 00:00:00' | datetime | increment_datetime(days=1, hours=6)}}""
 
+.. versionadded:: 1.1
+    ``increment_datetime`` filter added.
+
 date
     Converts a string to a ``datetime.date`` object::
 

--- a/docs/sphinx/scripts.rst
+++ b/docs/sphinx/scripts.rst
@@ -442,17 +442,20 @@ Other filters
 
 render
     Renders the expression (e.g. a variable) with Jinja2 and the current context. This can be used, for
-    example, to explicitly render context parameters that have been set with the `!noparse` tag::
+    example, to explicitly render context parameters that have been set with the ``!noparse`` tag::
 
         - base.context:
             foo: me
             bar: !noparse "{{ foo }}"
-        - when "{{ bar|render == 'me' }}"
+        - when: "{{ bar|render == 'me' }}"
           base.echo:
             msg: "It is {{ bar }}!"
 
-    Without using the `render` filter in the example, the `when` clause would evaluate to `false` because
-    the value of `bar` would still be `"{{ foo }}"` because of `!noparse`.
+    Without using the ``render`` filter in the example, the ``when`` clause would evaluate to ``false``
+    because the value of ``bar`` would still be ``"{{ foo }}"`` as a consequence of ``!noparse``.
+
+.. versionadded:: 1.1
+    ``render`` filter added.
 
 
 .. _PyYAML: https://pyyaml.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "python-dateutil",
     "deepmerge",
     "PyYAML",
-    "jinja2",
+    "jinja2>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/scriptengine/jinja.py
+++ b/src/scriptengine/jinja.py
@@ -45,6 +45,11 @@ def path_join(pathlist):
     return os.path.join(*pathlist)
 
 
+@jinja2.pass_context
+def render_filter(context, expression):
+    return render(expression, context)
+
+
 def filters():
     """Return all defined Jinja2 filters by their name and corresponding function"""
     return {
@@ -55,6 +60,7 @@ def filters():
         "dirname": dirname,
         "exists": exists,
         "path_join": path_join,
+        "render": render_filter,
     }
 
 

--- a/tests/jobs/test_conditionals.py
+++ b/tests/jobs/test_conditionals.py
@@ -1,5 +1,6 @@
 import yaml
 
+from scriptengine.engines import SimpleScriptEngine
 from scriptengine.yaml.parser import parse
 
 
@@ -31,3 +32,19 @@ def test_when_false(capsys):
     j.run({})
     captured = capsys.readouterr()
     assert "Hello, world!" not in captured.out
+
+
+def test_when_clause_parses_noparse_parameter(capsys):
+    s = from_yaml(
+        """
+        - base.context:
+            foo: me
+            bar: !noparse_jinja "{{ foo }}"
+        - when: "{{ bar == 'me' }}"
+          base.echo:
+            msg: Hello!
+        """
+    )
+    SimpleScriptEngine().run(s, context={})
+    captured = capsys.readouterr()
+    assert "Hello!" in captured.out

--- a/tests/jobs/test_conditionals.py
+++ b/tests/jobs/test_conditionals.py
@@ -40,7 +40,7 @@ def test_when_clause_parses_noparse_parameter(capsys):
         - base.context:
             foo: me
             bar: !noparse_jinja "{{ foo }}"
-        - when: "{{ bar == 'me' }}"
+        - when: "{{ bar|render == 'me' }}"
           base.echo:
             msg: Hello!
         """


### PR DESCRIPTION
Implements #121 

Add a filter that allows rendering within a Jinja expression using the current context. This is needed to solve, for example, the following example:
```yaml
- base.context:
    foo: "me"
    bar: !noparse "{{ foo }}"

- when: "{{ bar == 'me' }}"
  base.echo:
    msg: Hi!
```
which does not render the `when` clause expression as expected (i.e. `base.echo` is not executed.